### PR TITLE
Tree sequence

### DIFF
--- a/lib/annotated_document/Cargo.toml
+++ b/lib/annotated_document/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 authors = ["Tom Cornell <tom.cornell@gmail.com>"]
 
 [dependencies]
+indextree = "1.0.1"
 

--- a/lib/annotated_document/src/lib.rs
+++ b/lib/annotated_document/src/lib.rs
@@ -1,4 +1,12 @@
+extern crate indextree;
+
 use std::collections::HashMap;
+
+
+pub mod tree_sequence;
+pub mod node_label;
+
+use tree_sequence::TreeSequence;
 
 #[cfg(test)]
 mod tests {
@@ -10,7 +18,7 @@ mod tests {
 
 pub struct AnnotatedDocument {
     doc_string: String,
-    annotations: AnnotationSet,
+    tree_sequence: TreeSequence,
 }
 
 impl AnnotatedDocument {
@@ -18,157 +26,14 @@ impl AnnotatedDocument {
     pub fn new(text: &str) -> AnnotatedDocument {
         AnnotatedDocument {
             doc_string: String::from(text),
-            annotations: AnnotationSet::new(),
+            tree_sequence: TreeSequence::new(),
        }
     }
     pub fn get_text(&self) -> &str {
         &self.doc_string
     }
-
-    pub fn get_objects(&mut self) -> &mut AnnotationSet {
-        &mut self.annotations
+    pub fn get_trees(&mut self) -> &mut TreeSequence {
+        &mut self.tree_sequence
     }
 }
 
-
-pub struct AnnotationSet {
-    objects: NodeArena,
-}
-
-impl AnnotationSet {
-
-    pub fn new() -> AnnotationSet {
-        AnnotationSet { objects: NodeArena::new(), }
-    }
-
-    pub fn node_builder(&self) -> NodeBuilder {
-        NodeBuilder::new()
-    }
-
-    pub fn append(&mut self, node: Node) {
-        println!("Append node {:?}", node);
-    }
-
-    pub fn leaf_nodes(&self) -> LeafIter {
-        LeafIter::new(self)
-    }
-
-    pub fn get_first_leaf(&self) -> Option<&Node> {
-        unimplemented!();
-    }
-}
-
-pub struct LeafIter<'a> {
-    node_source: &'a NodeArena,
-    next_item: Option<&'a Node>,
-}
-
-impl<'a> LeafIter<'a> {
-    pub fn new(doc: &'a AnnotationSet) -> LeafIter<'a> {
-        LeafIter {
-            node_source: &doc.objects,
-            next_item: doc.get_first_leaf(),
-        }
-    }
-}
-
-impl<'a> Iterator for LeafIter<'a> {
-    type Item = &'a Node;
-    fn next(&mut self) -> Option<Self::Item> {
-        let retval = self.next_item;
-        self.next_item = match self.next_item {
-            None => None,
-            Some(nd) => nd.get_next_leaf()
-        };
-        retval
-    }
-}
-
-
-pub struct NodeBuilder;
-
-impl NodeBuilder {
-
-    pub fn new() -> NodeBuilder {
-        NodeBuilder {}
-    }
-
-    pub fn build(self) -> Node {
-        Node {}
-    }
-
-    pub fn span(mut self, begin: usize, end: usize) -> NodeBuilder {
-        self
-    }
-
-    pub fn string_val(mut self, key: &str, val: &str) -> NodeBuilder {
-        self
-    }
-
-    pub fn sym_val(mut self, key: &str, val: &str) -> NodeBuilder {
-        self
-    }
-
-    pub fn follows(mut self, pred: &mut Node) -> NodeBuilder {
-        self
-    }
-
-
-}
-
-#[derive(Debug)]
-pub struct Node;
-
-impl Node {
-
-    /// Return the string spanned by our begin/end offsets
-    pub fn word(&self) -> String {
-        // Need a reference back to the containing AnnotatedDocument.
-        // That's gonna hurt...
-        unimplemented!()
-    }
-
-    pub fn get_value(&self, key: &str) -> String {
-        unimplemented!()
-    }
-
-    pub fn get_next_leaf(&self) -> Option<&Node> {
-        unimplemented!()
-    }
-}
-
-
-
-struct Annotation {
-    data: HashMap<String, u64>,
-}
-
-impl Annotation {
-
-    fn new() -> Annotation {
-        Annotation {
-            data: HashMap::new(),
-        }
-    }
-
-}
-
-struct NodeArena;
-
-impl NodeArena {
-
-    fn new() -> NodeArena {
-        NodeArena {}
-    }
-
-}
-
-struct ValueTables;
-
-impl ValueTables {
-
-    fn new() -> ValueTables {
-        ValueTables {}
-    }
-
-}

--- a/lib/annotated_document/src/lib.rs
+++ b/lib/annotated_document/src/lib.rs
@@ -3,12 +3,14 @@ extern crate indextree;
 use std::collections::HashMap;
 
 
-pub mod tree_sequence;
+mod tree_sequence;
 mod node_label;
 
 pub use node_label::NodeLabel;
+pub use tree_sequence::TreeSequence;
+pub use tree_sequence::TreeCursor;
+pub use tree_sequence::CursorMemo;
 
-use tree_sequence::TreeSequence;
 
 #[cfg(test)]
 mod tests {

--- a/lib/annotated_document/src/lib.rs
+++ b/lib/annotated_document/src/lib.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 
 
 pub mod tree_sequence;
-pub mod node_label;
+mod node_label;
+
+pub use node_label::NodeLabel;
 
 use tree_sequence::TreeSequence;
 
@@ -32,8 +34,11 @@ impl AnnotatedDocument {
     pub fn get_text(&self) -> &str {
         &self.doc_string
     }
-    pub fn get_trees(&mut self) -> &mut TreeSequence {
+    pub fn get_trees_mut(&mut self) -> &mut TreeSequence {
         &mut self.tree_sequence
+    }
+    pub fn get_trees(&self) -> &TreeSequence {
+        &self.tree_sequence
     }
 }
 

--- a/lib/annotated_document/src/node_label.rs
+++ b/lib/annotated_document/src/node_label.rs
@@ -3,12 +3,6 @@
 //! Representation for data stored in tree nodes (and maybe elsewhere)
 
 use std::fmt;
-
-/// For node data
-///
-/// This is the data that the tree container generic will be bound to.
-///
-
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -22,13 +16,19 @@ impl NodeLabel {
         NodeLabel { span: None, attributes: HashMap::new(), }
     }
 
-    pub fn set_span(&mut self, begin: usize, end: usize) {
+    pub fn set_span(&mut self, begin: usize, end: usize) -> &mut Self {
         // TODO: Check for end < begin, etc.
         self.span = Some((begin, end));
+        self
     }
 
-    pub fn set_sym_val(&mut self, attr: &str, val: &str) {
+    pub fn get_span(&self) -> Option<(usize, usize)> {
+        self.span
+    }
+
+    pub fn set_sym_val(&mut self, attr: &str, val: &str) -> &mut Self {
         self.attributes.insert(attr.to_string(), val.to_string());
+        self
     }
 
     pub fn get_sym_val(&self, attr: &str) -> &str {

--- a/lib/annotated_document/src/node_label.rs
+++ b/lib/annotated_document/src/node_label.rs
@@ -38,6 +38,11 @@ impl NodeLabel {
 
 impl fmt::Display for NodeLabel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {} ", self.span.unwrap().0, self.span.unwrap().1)
+        match self.span {
+            None => write!(f, "(_, _)"),
+            Some((b, e)) => write!(f, "{} {} ", 
+                                      self.span.unwrap().0, 
+                                      self.span.unwrap().1)
+        }
     }
 }

--- a/lib/annotated_document/src/node_label.rs
+++ b/lib/annotated_document/src/node_label.rs
@@ -39,7 +39,7 @@ impl NodeLabel {
 impl fmt::Display for NodeLabel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.span {
-            None => write!(f, "(_, _)"),
+            None => write!(f, "_ _"),
             Some((b, e)) => write!(f, "{} {} ", 
                                       self.span.unwrap().0, 
                                       self.span.unwrap().1)

--- a/lib/annotated_document/src/node_label.rs
+++ b/lib/annotated_document/src/node_label.rs
@@ -1,0 +1,43 @@
+//! # node_label.rs
+//!
+//! Representation for data stored in tree nodes (and maybe elsewhere)
+
+use std::fmt;
+
+/// For node data
+///
+/// This is the data that the tree container generic will be bound to.
+///
+
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct NodeLabel {
+    span: Option<(usize, usize)>,
+    attributes: HashMap<String, String>,
+}
+
+impl NodeLabel {
+    pub fn new() -> NodeLabel {
+        NodeLabel { span: None, attributes: HashMap::new(), }
+    }
+
+    pub fn set_span(&mut self, begin: usize, end: usize) {
+        // TODO: Check for end < begin, etc.
+        self.span = Some((begin, end));
+    }
+
+    pub fn set_sym_val(&mut self, attr: &str, val: &str) {
+        self.attributes.insert(attr.to_string(), val.to_string());
+    }
+
+    pub fn get_sym_val(&self, attr: &str) -> &str {
+        &self.attributes[attr]
+    }
+}
+
+impl fmt::Display for NodeLabel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {} ", self.span.unwrap().0, self.span.unwrap().1)
+    }
+}

--- a/lib/annotated_document/src/tree_sequence.rs
+++ b/lib/annotated_document/src/tree_sequence.rs
@@ -1,6 +1,9 @@
 //! # tree_sequence.rs
 //!
-//! 
+//! Manage a sequence of trees. 
+//!
+//! Basically the many many children of a single root node that 
+//! remains implicit.
 
 
 use std::fmt;
@@ -26,12 +29,12 @@ impl TreeSequence {
         }
     }
 
-    pub fn unlock(&self, memo: CursorSnapshot) -> Cursor {
-        Cursor::new(memo.node, &self.arena)
+    pub fn activate(&self, memo: CursorMemo) -> TreeCursor {
+        TreeCursor::new(memo.node, &self.arena)
     }
 
-    pub fn first(&self) -> Cursor {
-        Cursor::new(self.first, &self.arena)
+    pub fn first(&self) -> TreeCursor {
+        TreeCursor::new(self.first, &self.arena)
     }
 
     pub fn print(&self) {
@@ -61,8 +64,8 @@ impl TreeSequence {
     /// if we were working on the very tail of the tree list. 
     /// That case has to be accounted for!
     ///
-    /// This should probably return a Cursor wrapping the new root node.
-    pub fn chunk(&mut self, lbl: NodeLabel, begin: CursorSnapshot, end: CursorSnapshot) {
+    /// This should probably return a TreeCursor wrapping the new root node.
+    pub fn chunk(&mut self, lbl: NodeLabel, begin: CursorMemo, end: CursorMemo) {
         // 1. Check that begin and end are not None
         // 2. Check that they are not equal
         let root: NodeId = self.arena.new_node(lbl);
@@ -81,24 +84,24 @@ impl TreeSequence {
 
 
 
-pub struct Cursor<'a> {
+pub struct TreeCursor<'a> {
     node: Option<NodeId>,
     arena: &'a TreeArena,
 }
 
 #[derive(Debug)]
-pub struct CursorSnapshot {
+pub struct CursorMemo {
     node: Option<NodeId>,
 }
 
 /// Once you move off the edge of the tree, you can't go back, so maybe
 /// this struct needs some lookahead methods as well?
 /// Maybe always leave behind a copy? Instead of returning Option<NodeId>,
-/// return a Cursor?
-impl<'a> Cursor<'a> {
+/// return a TreeCursor?
+impl<'a> TreeCursor<'a> {
 
-    pub fn new(node: Option<NodeId>, arena: &TreeArena) -> Cursor {
-        Cursor { node: node, arena }
+    pub fn new(node: Option<NodeId>, arena: &TreeArena) -> TreeCursor {
+        TreeCursor { node: node, arena }
     }
 
     pub fn is_valid(&self) -> bool {
@@ -112,8 +115,8 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    pub fn to_snapshot(&self) -> CursorSnapshot {
-        CursorSnapshot { node: self.node }
+    pub fn to_snapshot(&self) -> CursorMemo {
+        CursorMemo { node: self.node }
     }
 
     /// Move the cursor up
@@ -138,6 +141,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    /// Move the cursor to its right sibling
     pub fn next(&mut self) -> Option<NodeId> {
         match self.node.take() {
             Some(node) => {
@@ -148,6 +152,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    /// Move the cursor to its leftmost child
     pub fn first(&mut self) -> Option<NodeId> {
         match self.node.take() {
             Some(node) => {
@@ -160,9 +165,9 @@ impl<'a> Cursor<'a> {
 }
 
 
-impl<'a> fmt::Debug for Cursor<'a> {
+impl<'a> fmt::Debug for TreeCursor<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Cursor {{ node: {:?}, arena: ... }}", self.node)
+        write!(f, "TreeCursor {{ node: {:?}, arena: ... }}", self.node)
     }
 }
 
@@ -197,4 +202,14 @@ pub fn print_tree(node: NodeId, arena: &TreeArena, depth: i32) {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        //assert_eq!(4, add_two(2));
+    }
+}
 

--- a/lib/annotated_document/src/tree_sequence.rs
+++ b/lib/annotated_document/src/tree_sequence.rs
@@ -71,14 +71,18 @@ impl TreeSequence {
         let root: NodeId = self.arena.new_node(lbl);
         let end_id: NodeId = end.node.unwrap();
         let mut child: NodeId = begin.node.unwrap();
+        let b_off = self.arena[child].data.get_span().unwrap().0;
+        let mut e_off = 0;
         child.insert_before(root, &mut self.arena);
         while child != end_id {
+            e_off = self.arena[child].data.get_span().unwrap().1;
             //println!("DEBUG  {:?} != {:?}", child, end_id);
             root.append(child, &mut self.arena);
             let next_opt = self.arena[root].next_sibling();
             //println!("DEBUG  next_opt = {:?}", next_opt);
             child = next_opt.unwrap();
         }
+        self.arena[root].data.set_span(b_off, e_off);
     }
 }
 

--- a/lib/annotated_document/src/tree_sequence.rs
+++ b/lib/annotated_document/src/tree_sequence.rs
@@ -73,10 +73,10 @@ impl TreeSequence {
         let mut child: NodeId = begin.node.unwrap();
         child.insert_before(root, &mut self.arena);
         while child != end_id {
-            println!("DEBUG  {:?} != {:?}", child, end_id);
+            //println!("DEBUG  {:?} != {:?}", child, end_id);
             root.append(child, &mut self.arena);
             let next_opt = self.arena[root].next_sibling();
-            println!("DEBUG  next_opt = {:?}", next_opt);
+            //println!("DEBUG  next_opt = {:?}", next_opt);
             child = next_opt.unwrap();
         }
     }
@@ -115,7 +115,7 @@ impl<'a> TreeCursor<'a> {
         }
     }
 
-    pub fn to_snapshot(&self) -> CursorMemo {
+    pub fn to_memo(&self) -> CursorMemo {
         CursorMemo { node: self.node }
     }
 
@@ -177,7 +177,7 @@ impl<'a> fmt::Debug for TreeCursor<'a> {
 ///
 /// The root list is formed by a sequence of nodes connected as siblings,
 /// but with no parents.
-pub fn print_tree_sequence(node: Option<NodeId>, arena: &TreeArena, depth: i32) {
+fn print_tree_sequence(node: Option<NodeId>, arena: &TreeArena, depth: i32) {
     if node.is_none() {
         return;
     }
@@ -189,7 +189,7 @@ pub fn print_tree_sequence(node: Option<NodeId>, arena: &TreeArena, depth: i32) 
 /// Print a tree in outline form 
 ///
 /// Indent tab size is hard-coded as 4.
-pub fn print_tree(node: NodeId, arena: &TreeArena, depth: i32) {
+fn print_tree(node: NodeId, arena: &TreeArena, depth: i32) {
     // print label at indent
     let indent = depth * 4;
     for _ in 0..indent {

--- a/lib/annotated_document/src/tree_sequence.rs
+++ b/lib/annotated_document/src/tree_sequence.rs
@@ -1,0 +1,200 @@
+//! # tree_sequence.rs
+//!
+//! 
+
+
+use std::fmt;
+use indextree::Arena;
+use indextree::NodeId;
+use node_label::NodeLabel;
+
+type TreeArena = Arena<NodeLabel>;
+
+pub struct TreeSequence {
+    first: Option<NodeId>,
+    last: Option<NodeId>,
+    arena: TreeArena,
+}
+
+impl TreeSequence {
+
+    pub fn new() -> TreeSequence {
+        TreeSequence {
+            first: None,
+            last: None,
+            arena: TreeArena::new(),
+        }
+    }
+
+    pub fn unlock(&self, memo: CursorSnapshot) -> Cursor {
+        Cursor::new(memo.node, &self.arena)
+    }
+
+    pub fn first(&self) -> Cursor {
+        Cursor::new(self.first, &self.arena)
+    }
+
+    pub fn print(&self) {
+        print_tree_sequence(self.first, &self.arena, 0);
+    }
+
+    /// Create a new atomic tree and append it to the tree sequence 
+    ///
+    /// This should end up being roughly equivalent to chunk() with no 
+    /// child sequence.
+    pub fn push_back(&mut self, lbl: NodeLabel) {
+        let node = self.arena.new_node(lbl);
+        match self.last {
+            None => {
+                // then so is self.first
+                self.last = Some(node);
+                self.first = self.last;
+            }
+            Some(last_node) => {
+                last_node.insert_after(node, &mut self.arena);
+                self.last = Some(node);
+            }
+        }
+    }
+
+    /// `end` is not included in the interval. So it could be None, 
+    /// if we were working on the very tail of the tree list. 
+    /// That case has to be accounted for!
+    ///
+    /// This should probably return a Cursor wrapping the new root node.
+    pub fn chunk(&mut self, lbl: NodeLabel, begin: CursorSnapshot, end: CursorSnapshot) {
+        // 1. Check that begin and end are not None
+        // 2. Check that they are not equal
+        let root: NodeId = self.arena.new_node(lbl);
+        let end_id: NodeId = end.node.unwrap();
+        let mut child: NodeId = begin.node.unwrap();
+        child.insert_before(root, &mut self.arena);
+        while child != end_id {
+            println!("DEBUG  {:?} != {:?}", child, end_id);
+            root.append(child, &mut self.arena);
+            let next_opt = self.arena[root].next_sibling();
+            println!("DEBUG  next_opt = {:?}", next_opt);
+            child = next_opt.unwrap();
+        }
+    }
+}
+
+
+
+pub struct Cursor<'a> {
+    node: Option<NodeId>,
+    arena: &'a TreeArena,
+}
+
+#[derive(Debug)]
+pub struct CursorSnapshot {
+    node: Option<NodeId>,
+}
+
+/// Once you move off the edge of the tree, you can't go back, so maybe
+/// this struct needs some lookahead methods as well?
+/// Maybe always leave behind a copy? Instead of returning Option<NodeId>,
+/// return a Cursor?
+impl<'a> Cursor<'a> {
+
+    pub fn new(node: Option<NodeId>, arena: &TreeArena) -> Cursor {
+        Cursor { node: node, arena }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.node.is_some()
+    }
+
+    pub fn get(&self) -> Option<&NodeLabel> {
+        match self.node {
+            None => None,
+            Some(node) => Some(&self.arena[node].data)
+        }
+    }
+
+    pub fn to_snapshot(&self) -> CursorSnapshot {
+        CursorSnapshot { node: self.node }
+    }
+
+    /// Move the cursor up
+    ///
+    /// Returns the previous value of self.node.
+    /// It's based on an iterator. Imagine an iterator was sitting on the 
+    /// first element of a sequence. You would want to both get that value,
+    /// and increment the iterator. Otherwise you would never see that value.
+    /// There could be a `get()` method or something, but it would never 
+    /// work in a `for x in iter` pattern, I don't guess.
+    ///
+    /// This may not be the best behavior for a cursor, though.
+    /// Just always remember to use cursor.up().get(), and ignore the 
+    /// return value?
+    pub fn up(&mut self) -> Option<NodeId> {
+        match self.node.take() {
+            Some(node) => {
+                self.node = self.arena[node].parent();
+                Some(node)
+            }
+            None => None
+        }
+    }
+
+    pub fn next(&mut self) -> Option<NodeId> {
+        match self.node.take() {
+            Some(node) => {
+                self.node = self.arena[node].next_sibling();
+                Some(node)
+            }
+            None => None
+        }
+    }
+
+    pub fn first(&mut self) -> Option<NodeId> {
+        match self.node.take() {
+            Some(node) => {
+                self.node = self.arena[node].first_child();
+                Some(node)
+            }
+            None => None
+        }
+    }
+}
+
+
+impl<'a> fmt::Debug for Cursor<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Cursor {{ node: {:?}, arena: ... }}", self.node)
+    }
+}
+
+
+
+/// Used to print a root-list when there is no single root node.
+///
+/// The root list is formed by a sequence of nodes connected as siblings,
+/// but with no parents.
+pub fn print_tree_sequence(node: Option<NodeId>, arena: &TreeArena, depth: i32) {
+    if node.is_none() {
+        return;
+    }
+    for t in node.unwrap().following_siblings(arena) {
+        print_tree(t, arena, depth);
+    }
+}
+
+/// Print a tree in outline form 
+///
+/// Indent tab size is hard-coded as 4.
+pub fn print_tree(node: NodeId, arena: &TreeArena, depth: i32) {
+    // print label at indent
+    let indent = depth * 4;
+    for _ in 0..indent {
+        print!(" ");
+    }
+    println!("{}", arena[node].data);
+    // print child list at depth + 1
+    for t in node.children(arena) {
+        print_tree(t, arena, depth + 1);
+    }
+}
+
+

--- a/lib/annotated_document/tests/basic-test.rs
+++ b/lib/annotated_document/tests/basic-test.rs
@@ -2,8 +2,14 @@
 
 extern crate annotated_document;
 
-use annotated_document::AnnotatedDocument;
-use annotated_document::NodeLabel;
+use annotated_document::*;
+
+fn print_label(cursor: &TreeCursor, doc: &AnnotatedDocument) {
+    let label = cursor.get().unwrap();
+    let span = label.get_span().unwrap();
+    println!("({:>02}, {:>02}) [{}]", span.0, span.1,
+                      &doc.get_text()[span.0..span.1]);    
+}
 
 #[test]
 fn push_tokens_and_traverse() {
@@ -25,12 +31,52 @@ fn push_tokens_and_traverse() {
     // Traverse (and print)
     let mut cursor = doc.get_trees().first();
     while cursor.is_valid() {
-        {
-            let label = cursor.get().unwrap();
-            let span = label.get_span().unwrap();
-            println!("({}, {}) {}", span.0, span.1,
-                              &doc.get_text()[span.0..span.1]);
-        }
+        print_label(&cursor, &doc);
         cursor.next();
     }
+}
+
+#[test]
+fn test_chunking() {
+    let txt = "aa bb cc dd ee ff";
+    let mut doc = AnnotatedDocument::new(txt);
+    for (i, _) in txt.split_whitespace().enumerate() {
+        let b = i * 3;
+        let e = b + 2;
+        let mut lbl = NodeLabel::new();
+        lbl.set_span(b, e)
+           .set_sym_val("toktype", "WORD");
+        doc.get_trees_mut().push_back(lbl);
+    }
+
+    {
+        println!("====================");
+        let mut cursor = doc.get_trees().first();
+        while cursor.is_valid() {
+            print_label(&cursor, &doc);
+            cursor.next();
+        }
+        println!("====================");
+    }
+
+    let (first_child, last_child) = fake_parse(&doc);
+    let mut label = NodeLabel::new();
+    label.set_sym_val("cat", "cc_ee");
+    doc.get_trees_mut().chunk(label, first_child, last_child);
+    doc.get_trees().print();
+}
+
+fn fake_parse(doc: &AnnotatedDocument) -> (CursorMemo, CursorMemo) {
+    let mut cursor = doc.get_trees().first();   // reset cursor 
+    cursor.next();
+    cursor.next();
+    // cursor should now be sitting on [cc]
+    print_label(&cursor, &doc);
+    let first_child = cursor.to_memo();
+    cursor.next();
+    cursor.next();
+    cursor.next();
+    // cursor should now be sitting on [ff]
+    let last_child = cursor.to_memo();
+    (first_child, last_child)
 }

--- a/lib/annotated_document/tests/basic-test.rs
+++ b/lib/annotated_document/tests/basic-test.rs
@@ -1,6 +1,36 @@
 // Basic document test
 
 extern crate annotated_document;
-extern crate rs_regex;
 
 use annotated_document::AnnotatedDocument;
+use annotated_document::NodeLabel;
+
+#[test]
+fn push_tokens_and_traverse() {
+    // Fake tokenizer
+    let mut doc = AnnotatedDocument::new("01 Hello!");
+    let mut lbl0 = NodeLabel::new();
+    lbl0.set_span(0, 2)
+        .set_sym_val("toktype", "NUMBER");
+    doc.get_trees_mut().push_back(lbl0);
+    let mut lbl1 = NodeLabel::new();
+    lbl1.set_span(3, 8)
+        .set_sym_val("toktype", "WORD");
+    doc.get_trees_mut().push_back(lbl1);
+    let mut lbl2 = NodeLabel::new();
+    lbl2.set_span(8, 9)
+        .set_sym_val("toktype", "PUNCT");
+    doc.get_trees_mut().push_back(lbl2);
+
+    // Traverse (and print)
+    let mut cursor = doc.get_trees().first();
+    while cursor.is_valid() {
+        {
+            let label = cursor.get().unwrap();
+            let span = label.get_span().unwrap();
+            println!("({}, {}) {}", span.0, span.1,
+                              &doc.get_text()[span.0..span.1]);
+        }
+        cursor.next();
+    }
+}

--- a/lib/annotated_document/tests/basic-test.rs
+++ b/lib/annotated_document/tests/basic-test.rs
@@ -4,39 +4,3 @@ extern crate annotated_document;
 extern crate rs_regex;
 
 use annotated_document::AnnotatedDocument;
-
-#[test]
-fn low_level() {
-    let mut doc = AnnotatedDocument::new("Hello world");
-    let mut node1 = doc.node_builder()
-        .string_val("lemma", "hello")
-        .span(0, 5)
-        .build();
-    let mut node2 = doc.node_builder()
-        .span(7, 11)
-        .string_val("lemma", "world")
-        .follows(&mut node1)
-        .build();
-}
-
-#[test]
-fn tokenization_test() {
-    let mut doc = AnnotatedDocument::new("Hello world");
-    let mut node1 = doc.node_builder()
-        .span(0, 5)
-        .sym_val("toktype", "WORD")
-        .build();
-    let mut _node2 = doc.node_builder()
-        .span(7, 11)
-        .sym_val("toktype", "WORD")
-        .follows(&mut node1)
-        .build();
-
-    for t in doc.leaf_nodes() {
-        println!("{}: {}", t.word(), t.get_value("lemma"));
-    }
-}
-
-
-
-

--- a/lib/regex_tokenizer/src/english_rules.rs
+++ b/lib/regex_tokenizer/src/english_rules.rs
@@ -12,7 +12,7 @@ use regex_tokenizer::TokenReactor;
 use regex_tokenizer::ThompsonProgramBuilder;
 use regex_tokenizer::RegexTokenizer;
 use annotated_document::AnnotatedDocument;
-use annotated_document::node_label::NodeLabel;
+use annotated_document::NodeLabel;
 
 pub struct EnglishTokenizer {
     matcher: ThompsonInterpreter,
@@ -31,17 +31,17 @@ impl EnglishTokenizer {
         }
     }
 
-    fn word_action(&mut self, begin: usize, end: usize, token: &mut NodeLabel) {
+    fn word_action(&mut self, _begin: usize, _end: usize, token: &mut NodeLabel) {
         //println!("WORD [{}] at {}", &doc.get_text()[begin..end], begin);
         token.set_sym_val("toktype", "WORD");
     }
 
-    fn num_action(&mut self, begin:usize, end: usize, token: &mut NodeLabel) {
+    fn num_action(&mut self, _begin:usize, _end: usize, token: &mut NodeLabel) {
         //println!("NUMBER [{}] at {}", &doc.get_text()[begin..end], begin);
         token.set_sym_val("toktype", "NUMBER");
     }
 
-    fn punct_action(&mut self, begin: usize, end: usize, token: &mut NodeLabel) {
+    fn punct_action(&mut self, _begin: usize, _end: usize, token: &mut NodeLabel) {
         //println!("PUNCT [{}] at {}", &doc.get_text()[begin..end], begin);
         token.set_sym_val("toktype", "PUNCT");
     }
@@ -79,7 +79,7 @@ impl TokenReactor for EnglishTokenizer {
             &doc.get_text()[begin..end], 
             begin
         );
-        doc.get_trees().push_back(token);
+        doc.get_trees_mut().push_back(token);
     }
 
     /// Skip an unhandled character

--- a/lib/regex_tokenizer/src/regex_tokenizer.rs
+++ b/lib/regex_tokenizer/src/regex_tokenizer.rs
@@ -1,11 +1,9 @@
 
-use nlpsvc_regex::reinterp::ThompsonInterpreter;
 use nlpsvc_regex::reinterp::TokenRecognizer;
 use nlpsvc_regex::retrans::RegexTranslator;
 use nlpsvc_regex::reparse;
 use nlpsvc_regex::reprog::Program;
 use annotated_document::AnnotatedDocument;
-use annotated_document::AnnotationSet;
 
 
 /// Trait for holding actions to take upon token recognition
@@ -41,7 +39,6 @@ pub trait RegexTokenizer: TokenRecognizer + TokenReactor {
                 }
                 Some(match_rec) => {
                     let new_pos = pos + match_rec.len;
-                    //self.append(pos, &doc.get_text()[pos..new_pos], match_rec.rule, doc.get_objects());
                     self.append(pos, new_pos, match_rec.rule, doc);
                     pos = new_pos;
                 }

--- a/util/tokenizer/src/main.rs
+++ b/util/tokenizer/src/main.rs
@@ -1,8 +1,8 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// package: regex_tokenizer
+// util/tokenizer/src/main.rs
 //
-// main.rs 
+// Tokenizer 
 
 extern crate getopts;
 extern crate annotated_document;
@@ -100,7 +100,7 @@ impl TextSource {
 fn main() {
     let cfg = configure();
     let text_src = TextSource::new(&cfg);
-    println!("\n{}", text_src.get_text());
+    println!("====================\n{}\n====================", text_src.get_text());
 
     let mut tokenizer = EnglishTokenizer::new();   // compile regex patterns
     let mut doc = AnnotatedDocument::new(text_src.get_text());


### PR DESCRIPTION
Add a tree sequence to AnnotatedDocument, for syntactic parsing. Support tokenization rule API and basic chunking.

In the end I had to use an index-based arena for the tree nodes (the indextree crate). I don't see a way to implement syntax trees that you can move around in freely and modify without some degree of unsafety. That said, using pointers and explicitly unsafe code might at least not give the impression that nothing can go wrong, which you might otherwise get from pretending that vector indices are somehow not also pointers...